### PR TITLE
Added ability to run via command line with arguments

### DIFF
--- a/MegaKeep/MegaKeep.cs
+++ b/MegaKeep/MegaKeep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -10,10 +11,26 @@ namespace MegaKeep
 	public partial class MegaKeep : Form
 	{
 		private string _local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-
+		private string[] commandlineArgs = { };
 		public MegaKeep()
 		{
 			InitializeComponent();
+		}
+		public MegaKeep(string[] args)
+		{
+			InitializeComponent();
+			if (args.Length > 0)
+			{
+				commandlineArgs = args;
+				var txtFileIndex = Array.IndexOf(args, "--txtFile") + 1;
+				var txtFile = args[txtFileIndex];
+				if (File.Exists(txtFile))
+				{
+					Properties.Settings.Default.Location = txtFile;
+					Properties.Settings.Default.Save();
+					txtPath.Text = txtFile;
+				}
+			}
 		}
 
 		private async void btnRun_ClickAsync(object sender, EventArgs e)
@@ -50,6 +67,8 @@ namespace MegaKeep
 
 			// run the processes in a task so it doesn't freeze the ui
 			await Task.Run(() => Work(lines));
+			if (commandlineArgs.Contains("--cli"))// if running in cli mode, closes window after running work.
+				this.Close();
 		}
 
 		private string Login(string user, string pass)
@@ -218,6 +237,11 @@ namespace MegaKeep
 
 		private void MegaKeep_Load(object sender, EventArgs e)
 		{
+			// if started with arg "--cli" simulate button click in UI
+			if (commandlineArgs.Contains("--cli"))
+			{
+				btnRun.PerformClick();
+			}
 			txtPath.Text = Properties.Settings.Default.Location;
 		}
 

--- a/MegaKeep/Program.cs
+++ b/MegaKeep/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace MegaKeep
@@ -9,11 +10,31 @@ namespace MegaKeep
 		/// The main entry point for the application.
 		/// </summary>
 		[STAThread]
-		static void Main()
+		static void Main(string[] args)
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
-			Application.Run(new MegaKeep());
+			CommandArgs(args);
+			Application.Run(new MegaKeep(args)); //passes args to new start method
+		}
+
+		// sets the path to the text file passed via command line.
+		static void CommandArgs(string[] args)
+		{
+			if (args.Length > 0)
+			{
+				var txtFileIndex = Array.IndexOf(args, "--txtFile") + 1;
+				if(args[txtFileIndex] != null)
+				{
+					var txtFile = args[txtFileIndex];
+					if (File.Exists(txtFile))
+					{
+						Properties.Settings.Default.Location = txtFile;
+						Properties.Settings.Default.Save();
+					}
+				}
+				
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is a change that adds command line arguments to the exe.  This can be used for scripting.

MegaKeep.exe --cli       = will start the program and run the currently loaded txt file.

MegaKeep.exe --cli --txtFile "C:\Path\to\loginFile.txt"       = same as above, but will use the txt file for logins.